### PR TITLE
Added volume boost past 100%, up to 500%

### DIFF
--- a/Ver1.0.0/content.js
+++ b/Ver1.0.0/content.js
@@ -1,9 +1,40 @@
 (function() {
     let tabId;
+    let audioContext;
+    let gainNode;
+    let connectedElements = new WeakSet();
+
+    function initAudioContext() {
+        if (!audioContext) {
+            audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            gainNode = audioContext.createGain();
+            gainNode.connect(audioContext.destination);
+        }
+    }
 
     function setVolume(volume) {
         document.querySelectorAll("video, audio").forEach(media => {
-            media.volume = volume;
+            if (volume > 1.0) {
+                // Use Web Audio API for amplification
+                initAudioContext();
+                media.volume = 1.0; // Max native volume
+                gainNode.gain.value = volume; // Apply boost
+                
+                // Connect element to gain node if not already connected
+                if (!connectedElements.has(media)) {
+                    try {
+                        const source = audioContext.createMediaElementSource(media);
+                        source.connect(gainNode);
+                        connectedElements.add(media);
+                    } catch (e) {
+                        console.warn('Could not connect media element to Web Audio API:', e);
+                    }
+                }
+            } else {
+                // Normal volume: use element's native volume
+                media.volume = volume;
+                if (gainNode) gainNode.gain.value = 1.0;
+            }
         });
     }
 

--- a/Ver1.0.0/popup.js
+++ b/Ver1.0.0/popup.js
@@ -16,6 +16,28 @@ document.addEventListener("DOMContentLoaded", async () => {
         chrome.storage.local.set({ darkMode: themeToggle.checked });
     });
 
+    // Convert slider position to volume percentage
+    function sliderToVolume(sliderValue) {
+        const pos = parseInt(sliderValue);
+        if (pos <= 100) {
+            // Fine control: 0-100% (1% increments)
+            return pos;
+        } else {
+            // Coarse control: 100-500% (10% increments)
+            return 100 + ((pos - 100) * 10);
+        }
+    }
+
+    // Convert volume percentage to slider position
+    function volumeToSlider(volume) {
+        const vol = parseInt(volume);
+        if (vol <= 100) {
+            return vol;
+        } else {
+            return 100 + Math.round((vol - 100) / 10);
+        }
+    }
+
     async function updatePopup() {
         const tabs = await chrome.tabs.query({ audible: true });
         const storedVolumes = await chrome.storage.local.get(null);
@@ -36,17 +58,21 @@ document.addEventListener("DOMContentLoaded", async () => {
             const slider = document.createElement("input");
             slider.type = "range";
             slider.min = "0";
-            slider.max = "100";
-            slider.value = storedVolumes[tab.id] || 100;
+            slider.max = "140"; // 0-100 (fine) + 100-500 in 40 steps of 10% each
+            
+            // Set default value (100% = slider position 100)
+            const storedVolume = storedVolumes[tab.id] || 100;
+            slider.value = volumeToSlider(storedVolume);
         
             const percentage = document.createElement("span");
             percentage.classList.add("volume-percentage");
-            percentage.textContent = slider.value + "%";
+            percentage.textContent = sliderToVolume(slider.value) + "%";
         
             slider.oninput = () => {
-                const volume = slider.value / 100;
-                percentage.textContent = slider.value + "%";
-                chrome.storage.local.set({ [tab.id]: slider.value });
+                const volumePercent = sliderToVolume(slider.value);
+                const volume = volumePercent / 100; // This now goes from 0.0 to 5.0
+                percentage.textContent = volumePercent + "%";
+                chrome.storage.local.set({ [tab.id]: volumePercent });
         
                 chrome.tabs.sendMessage(tab.id, { action: "updateVolume", tabId: tab.id, volume });
             };


### PR DESCRIPTION
Now the slider can boost the volume of a tab by 5x by using a api
The slider is set by deafult to 100%
Steps from 0% to 100% are "finer" while from 100% to 500% are "rougher" in terms of increments
(Still throws some error in line 11 of content.js)

